### PR TITLE
Fix/more handler robustness

### DIFF
--- a/tom_nonlocalizedevents/alertstream_handlers/gw_event_handler.py
+++ b/tom_nonlocalizedevents/alertstream_handlers/gw_event_handler.py
@@ -54,11 +54,11 @@ def handle_message(message):
         bytes_message = message
     fields = extract_fields(bytes_message.decode('utf-8'), EXPECTED_FIELDS)
     if fields:
-        nonlocalizedevent, created = NonLocalizedEvent.objects.get_or_create(
+        nonlocalizedevent, nle_created = NonLocalizedEvent.objects.get_or_create(
             event_id=fields['TRIGGER_NUM'],
             event_type=NonLocalizedEvent.NonLocalizedEventType.GRAVITATIONAL_WAVE,
         )
-        if created:
+        if nle_created:
             logger.info(f"Ingested a new GW event with id {fields['TRIGGER_NUM']} from alertstream")
         # Next attempt to ingest and build the localization of the event
         localization = create_localization_for_multiorder_fits(

--- a/tom_nonlocalizedevents/alertstream_handlers/gw_event_handler.py
+++ b/tom_nonlocalizedevents/alertstream_handlers/gw_event_handler.py
@@ -1,10 +1,12 @@
 ''' This class defines a message handler for a tom_alertstreams connection to GW events
 
 '''
-from tom_nonlocalizedevents.models import NonLocalizedEvent, EventSequence
-from tom_nonlocalizedevents.healpix_utils import create_localization_for_multiorder_fits
 import logging
 import os
+import traceback
+
+from tom_nonlocalizedevents.models import NonLocalizedEvent, EventSequence
+from tom_nonlocalizedevents.healpix_utils import create_localization_for_multiorder_fits
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
There were two different stack traces, one local, one on `tom-demo-dev` that put the Kafka client in a bad state. 
I'm hoping this try..except will put an end to that. (I'm monitoring the logs pretty regularly anyway, so I think I'll still be aware of the error and warnings without breaking the ingester).  Thoughts?

The stack traces if you're interested:
[tom_nonlocalozedevents-ingester-stacktrace.txt](https://github.com/TOMToolkit/tom_nonlocalizedevents/files/10864937/tom_nonlocalozedevents-ingester-stacktrace.txt)
