### PR TITLE
return nonlocalizedevent when retracted

### DIFF
--- a/tom_nonlocalizedevents/alertstream_handlers/igwn_event_handler.py
+++ b/tom_nonlocalizedevents/alertstream_handlers/igwn_event_handler.py
@@ -30,7 +30,7 @@ def handle_igwn_message(message: JSONBlob, metadata: Metadata):
         return None, None
 
     if alert.get('alert_type', '') == 'RETRACTION':
-        nonlocalizedevent = NonLocalizedEvent.objects.update_or_create(
+        nonlocalizedevent, nle_created = NonLocalizedEvent.objects.update_or_create(
             event_id=alert['superevent_id'],
             event_type=NonLocalizedEvent.NonLocalizedEventType.GRAVITATIONAL_WAVE,
             defaults={'state': NonLocalizedEvent.NonLocalizedEventState.RETRACTED}

--- a/tom_nonlocalizedevents/alertstream_handlers/igwn_event_handler.py
+++ b/tom_nonlocalizedevents/alertstream_handlers/igwn_event_handler.py
@@ -27,15 +27,15 @@ def handle_igwn_message(message: JSONBlob, metadata: Metadata):
     logger.warning(f"Handling igwn alert: {alert}")
     # Only store test alerts if we are configured to do so
     if alert.get('superevent_id', '').startswith('M') and not settings.SAVE_TEST_ALERTS:
-        return
+        return None, None
 
     if alert.get('alert_type', '') == 'RETRACTION':
-        NonLocalizedEvent.objects.update_or_create(
+        nonlocalizedevent = NonLocalizedEvent.objects.update_or_create(
             event_id=alert['superevent_id'],
             event_type=NonLocalizedEvent.NonLocalizedEventType.GRAVITATIONAL_WAVE,
             defaults={'state': NonLocalizedEvent.NonLocalizedEventState.RETRACTED}
         )
-        return
+        return nonlocalizedevent, None
 
     nonlocalizedevent, nle_created = NonLocalizedEvent.objects.get_or_create(
         event_id=alert['superevent_id'],


### PR DESCRIPTION
This just returns the `NonLocalizedEvent` from `handle_igwn_message` when the alert is a retraction. It also keeps the number of return values constant, whether it's a test alert, real alert, or retraction.