### PR TITLE
capitalize MLy pipeline

### DIFF
--- a/tom_nonlocalizedevents/healpix_utils.py
+++ b/tom_nonlocalizedevents/healpix_utils.py
@@ -132,7 +132,7 @@ def create_localization_for_skymap(nonlocalizedevent: NonLocalizedEvent, skymap_
         localization = EventLocalization.objects.get(nonlocalizedevent=nonlocalizedevent, skymap_hash=skymap_uuid)
     except EventLocalization.DoesNotExist:
         skymap = Table.read(BytesIO(skymap_bytes))
-        is_burst = pipeline in ['CWB', 'oLIB', 'mLy']
+        is_burst = pipeline in ['CWB', 'oLIB', 'MLy']
         if not is_burst:
             distance_mean = skymap.meta['DISTMEAN']
             distance_std = skymap.meta['DISTSTD']


### PR DESCRIPTION
According to the [IGWN public alerts guide](https://emfollow.docs.ligo.org/userguide/content.html), the MLy pipeline is capitalized. We need this to exactly match so that MLy alerts are recognized as burst alerts and we don't look for DISTMEAN in the header of the skymap file (which causes the alert listener to crash). I noticed this because of a recent alert [S250111bh](https://gracedb.ligo.org/superevents/S250111bh/).