### PR TITLE
update external coincidence details with new alerts

### DIFF
--- a/tom_nonlocalizedevents/alertstream_handlers/igwn_event_handler.py
+++ b/tom_nonlocalizedevents/alertstream_handlers/igwn_event_handler.py
@@ -77,8 +77,7 @@ def handle_igwn_message(message: JSONBlob, metadata: Metadata):
                     is_combined=True, pipeline=pipeline
                 )
                 external_coincidence, _ = ExternalCoincidence.objects.get_or_create(
-                    localization=combined_localization,
-                    defaults={'details': alert.get('external_coinc')}
+                    localization=combined_localization, details=alert.get('external_coinc')
                 )
             except Exception as e:
                 external_coincidence = None


### PR DESCRIPTION
Currently, new IGWN alerts with updated external coincidence parameters are not saved correctly. If they have the same sky map (`localization`) as a previous external coincidence object, they are not modified, even if the parameters (`details`) are different. This solves that issue by passing the details directly to the `get_or_create` method, rather than as a default.

For an example of an alert like this, see [S250223dk](https://gracedb.ligo.org/superevents/S250223dk/).