### PR TITLE
fix bug with sorting astropy table in place after generating normalized distances

### DIFF
--- a/tom_nonlocalizedevents/healpix_utils.py
+++ b/tom_nonlocalizedevents/healpix_utils.py
@@ -25,6 +25,7 @@ import uuid
 import sys
 import json
 import logging
+from copy import deepcopy
 
 # from django.db.models import Sum, Subquery, F, Min
 # from tom_nonlocalizedevents_base.settings import DATABASES
@@ -82,12 +83,13 @@ def get_confidence_regions(skymap: Table):
     """
     try:
         # Sort the pixels of the sky map by descending probability density
-        skymap.sort('PROBDENSITY', reverse=True)
+        skymap_sort = deepcopy(skymap)
+        skymap_sort.sort('PROBDENSITY', reverse=True)
         # Find the area of each pixel
-        level, ipix = ah.uniq_to_level_ipix(skymap['UNIQ'])
+        level, ipix = ah.uniq_to_level_ipix(skymap_sort['UNIQ'])
         pixel_area = ah.nside_to_pixel_area(ah.level_to_nside(level))
         # Calculate the probability within each pixel: the pixel area times the probability density
-        prob = pixel_area * skymap['PROBDENSITY']
+        prob = pixel_area * skymap_sort['PROBDENSITY']
         # Calculate the cumulative sum of the probability
         cumprob = np.cumsum(prob)
         # Find the pixel for which the probability sums to 0.5 (0.9)


### PR DESCRIPTION
In comparing "by-hand-derived" values for distances along the line of sight (LOS) in the localization map for a GW event I discovered that the distance from querying the django tables did not match the "by-hand" values. These by-hand values were computed using healpy alone, astropy-healpix alone, and ligo.skymap + healpy. All methods produce consistent results not in agreement with the TOMToolkit derived values for the LOS distances stored in the SkymapTile object/database.

Upon further inspection of the `tom_nonlocalizedevent.healpix_util` code I discovered the following sequence of events occuring in the [`create_localization_from_skymap`](https://github.com/TOMToolkit/tom_nonlocalizedevents/blob/b93ef187a13e3446dd8fa273b72b75c81103b3ff/tom_nonlocalizedevents/healpix_utils.py#L125) code:
1. The normalized distance was calculated from an astropy Table called `skymap` using `ligo.skymap.distance.parameters_to_moments`. In the output normalized distances the order is preserved as compared to the original `skymap` table.
2. [Later on](https://github.com/TOMToolkit/tom_nonlocalizedevents/blob/b93ef187a13e3446dd8fa273b72b75c81103b3ff/tom_nonlocalizedevents/healpix_utils.py#L159) in the `create_localization_from_skymap` code the function  `get_confidence_regions` is called, which seems to extract the 50th and 90th probability contours from the skymap. 
3. Within [`get_confidence_regions`](https://github.com/TOMToolkit/tom_nonlocalizedevents/blob/b93ef187a13e3446dd8fa273b72b75c81103b3ff/tom_nonlocalizedevents/healpix_utils.py#L78C5-L78C27) the `skymap` table is sorted [_in place_](https://github.com/TOMToolkit/tom_nonlocalizedevents/blob/b93ef187a13e3446dd8fa273b72b75c81103b3ff/tom_nonlocalizedevents/healpix_utils.py#L85)
4. The _sorted_ `skymap` table rows [are iterated](https://github.com/TOMToolkit/tom_nonlocalizedevents/blob/b93ef187a13e3446dd8fa273b72b75c81103b3ff/tom_nonlocalizedevents/healpix_utils.py#L179) over to generate the SkymapTile object/database rows. Within this loop, the  index of the row (which is purely the index ranging from 0 -> len(table)-1, indexing is unfortunately not preserved in astropy tables like it is in pandas dataframes) is used to get the normalized distance from the `row_dist_mean` and `row_dist_std` variables. 

However,  `row_dist_mean` and `row_dist_std` were derived from the pre-sorted astropy table. This means the indices of `skymap` and   `row_dist_mean`/`row_dist_std` are no longer aligned. Hence, the distances stored in the SkymapTile objects are incorrect.

In this PR I fix this issue by deepcopying the `skymap` table before sorting it. Note that this can be rather memory intensive (but usually not time intensive as far as I'm aware) and for large skymaps could cause issues. Some other options I see are:
1. Sort the `skymap` table in place right after loading it. The problem with this is that a lot of the `ligo.skymap` code relies on the ordering of the inputs, especially in the case of nested healpix indices, for deriving properties from the skymap. For this reason, I think this approach should be disfavored.
2. Instead of sorting the astropy table itself we could sort the index and use `skymap[sorted_index]` throughout the `get_confidence_regions` function. This may be less readable but probably less memory intensive, so I'm happy to implement this instead if preferred. 

Let me know if you have any questions or would like to discuss further! Regardless, I think this is a classic sorting -> index mismatch bug that should be fixed.